### PR TITLE
actually maintain uniqueness in package index

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function addAll(packages, packageIndex) {
 
 		var package = p + '@' + packages[p]
 
-		if (~~packageIndex.indexOf(package)) {
+		if (packageIndex.indexOf(package) === -1) {
 			packageIndex.push(package)
 		}
 	}	


### PR DESCRIPTION
Before, it would've added a package unless it was a duplicate of the first one in the array.

In JavaScript, the "double-tilde idiom" produces results similar to the floor function, but not quite.  It also produces bewilderment in the mind of a programmer unfamiliar with JS minutiae.  It's best to avoid it.
