### PR TITLE
Solves issue #68 - Author field in babel is not coming trough anymore

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,7 +48,7 @@ module.exports = rc('license-report', {
 	npmTokenEnvVar: 'NPM_TOKEN',
 
 	/*
-		an array of package names that will be excluded from the  report
+		an array of package names that will be excluded from the report
 	*/
 	exclude: [],
 

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -68,6 +68,10 @@ async function getPackageReportData(packageEntry, installedVersions) {
 			}
 			author += json.author.url;
 		}
+	} else {
+		if ((typeof json.author === 'string') || (json.author instanceof String)) {
+			author = json.author;
+		}
 	}
 
 	return {

--- a/test/endToEnd.test.js
+++ b/test/endToEnd.test.js
@@ -64,7 +64,7 @@ describe('end to end test for configuration', function () {
 	it('produce a json report without option "only"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${packagePath}`)
 		const result = JSON.parse(stdout)
-		const expectedLengthOfResult = 10
+		const expectedLengthOfResult = 11
 		const expectedWarning = stderr.includes(`package-lock.json' is required to get installed versions of packages`)
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
@@ -74,7 +74,7 @@ describe('end to end test for configuration', function () {
 	it('produce a json report with option "only=prod"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${packagePath} --only=prod`)
 		const result = JSON.parse(stdout)
-		const expectedLengthOfResult = 4
+		const expectedLengthOfResult = 5
 		const expectedWarning = stderr.includes(`package-lock.json' is required to get installed versions of packages`)
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)
@@ -84,7 +84,7 @@ describe('end to end test for configuration', function () {
 	it('produce a json report with option "only=prod,opt,peer"', async () => {
 		const { stdout, stderr } = await execAsPromise(`node ${scriptPath} --package=${packagePath} --only=prod,opt,peer`)
 		const result = JSON.parse(stdout)
-		const expectedLengthOfResult = 9
+		const expectedLengthOfResult = 10
 		const expectedWarning = stderr.includes(`package-lock.json' is required to get installed versions of packages`)
 
 		assert.strictEqual(result.length, expectedLengthOfResult, `expected the list to contain ${expectedLengthOfResult} elements`)

--- a/test/fixture/packageForE2eTest.json
+++ b/test/fixture/packageForE2eTest.json
@@ -5,7 +5,8 @@
     "@kessler/tableify": "^1.0.2",
     "debug": "^4.3.2",
     "eol": "^0.9.1",
-    "got": "^11.8.2"
+    "got": "^11.8.2",
+    "react-hook-form": "^7.27.0"
   },
   "devDependencies": {
     "mocha": "^9.1.1"

--- a/test/getPackageReportData.test.js
+++ b/test/getPackageReportData.test.js
@@ -9,14 +9,48 @@ const getPackageReportData = require('../lib/getPackageReportData.js')
 describe('getPackageReportData', function() {
 	this.timeout(20000)
 
-	it('gets the package report data', async () => {
+	it('gets the package report data for package with author name only', async () => {
 		const installedVersions = { async: '3.2.0' }
 		const packageEntry = { name: 'async', fullName: 'async', version: '>0.0.1' }
 		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
 
 		assert.strictEqual(packageReportData.name, 'async')
 		assert.strictEqual(packageReportData.licenseType, 'MIT')
+		assert.strictEqual(packageReportData.author, 'Caolan McMahon')
 		assert.strictEqual(packageReportData.link, 'git+https://github.com/caolan/async.git')
+	})
+
+	it('gets the package report data for package with author email only', async () => {
+		const installedVersions = { 'react-hook-form': '7.27.0' }
+		const packageEntry = { name: 'react-hook-form', fullName: 'react-hook-form', version: '^7.27.0' }
+		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
+
+		assert.strictEqual(packageReportData.name, 'react-hook-form')
+		assert.strictEqual(packageReportData.licenseType, 'MIT')
+		assert.strictEqual(packageReportData.author, 'bluebill1049@hotmail.com')
+		assert.strictEqual(packageReportData.link, 'git+https://github.com/react-hook-form/react-hook-form.git')
+	})
+
+	it('gets the package report data for package with author name, email and url', async () => {
+		const installedVersions = { 'text-table': '0.2.0' }
+		const packageEntry = { name: 'text-table', fullName: 'text-table', version: '0.2.0' }
+		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
+
+		assert.strictEqual(packageReportData.name, 'text-table')
+		assert.strictEqual(packageReportData.licenseType, 'MIT')
+		assert.strictEqual(packageReportData.author, 'James Halliday mail@substack.net http://substack.net')
+		assert.strictEqual(packageReportData.link, 'git://github.com/substack/text-table.git')
+	})
+
+	it('gets the package report data for package without author field', async () => {
+		const installedVersions = { 'got': '11.8.2' }
+		const packageEntry = { name: 'got', fullName: 'got', version: '^11.8.1' }
+		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
+
+		assert.strictEqual(packageReportData.name, 'got')
+		assert.strictEqual(packageReportData.licenseType, 'MIT')
+		assert.strictEqual(packageReportData.author, '')
+		assert.strictEqual(packageReportData.link, 'git+https://github.com/sindresorhus/got.git')
 	})
 
 	it('gets the scoped package report data', async () => {

--- a/test/getPackageReportData.test.js
+++ b/test/getPackageReportData.test.js
@@ -9,18 +9,18 @@ const getPackageReportData = require('../lib/getPackageReportData.js')
 describe('getPackageReportData', function() {
 	this.timeout(20000)
 
-	it('gets the package report data for package with author name only', async () => {
-		const installedVersions = { async: '3.2.0' }
-		const packageEntry = { name: 'async', fullName: 'async', version: '>0.0.1' }
+	it('gets the package report data for package with author string (name)', async () => {
+		const installedVersions = { '@babel/cli': '7.17.3' }
+		const packageEntry = { name: '@babel/cli', fullName: '@babel/cli', version: '^7.17.0' }
 		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
 
-		assert.strictEqual(packageReportData.name, 'async')
+		assert.strictEqual(packageReportData.name, '@babel/cli')
 		assert.strictEqual(packageReportData.licenseType, 'MIT')
-		assert.strictEqual(packageReportData.author, 'Caolan McMahon')
-		assert.strictEqual(packageReportData.link, 'git+https://github.com/caolan/async.git')
+		assert.strictEqual(packageReportData.author, 'The Babel Team (https://babel.dev/team)')
+		assert.strictEqual(packageReportData.link, 'https://github.com/babel/babel.git')
 	})
 
-	it('gets the package report data for package with author email only', async () => {
+	it('gets the package report data for package with author string (email)', async () => {
 		const installedVersions = { 'react-hook-form': '7.27.0' }
 		const packageEntry = { name: 'react-hook-form', fullName: 'react-hook-form', version: '^7.27.0' }
 		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
@@ -31,7 +31,18 @@ describe('getPackageReportData', function() {
 		assert.strictEqual(packageReportData.link, 'git+https://github.com/react-hook-form/react-hook-form.git')
 	})
 
-	it('gets the package report data for package with author name, email and url', async () => {
+	it('gets the package report data for package with author object (name)', async () => {
+		const installedVersions = { async: '3.2.0' }
+		const packageEntry = { name: 'async', fullName: 'async', version: '>0.0.1' }
+		const packageReportData = await getPackageReportData(packageEntry, installedVersions)
+
+		assert.strictEqual(packageReportData.name, 'async')
+		assert.strictEqual(packageReportData.licenseType, 'MIT')
+		assert.strictEqual(packageReportData.author, 'Caolan McMahon')
+		assert.strictEqual(packageReportData.link, 'git+https://github.com/caolan/async.git')
+	})
+
+	it('gets the package report data for package with author object (name, email, url)', async () => {
 		const installedVersions = { 'text-table': '0.2.0' }
 		const packageEntry = { name: 'text-table', fullName: 'text-table', version: '0.2.0' }
 		const packageReportData = await getPackageReportData(packageEntry, installedVersions)


### PR DESCRIPTION
I found the bug: 
the projects used for the tests all contain an object as author field (even if it only has a 'name' property);
but babel uses a string as author field in package.json.

This pr solves this error.